### PR TITLE
Support for not-English ESO localizations

### DIFF
--- a/ESO_Discord_RichPresence_Client/App.config
+++ b/ESO_Discord_RichPresence_Client/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="ESO_Discord_RichPresence_Client.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
@@ -48,4 +48,12 @@
             </setting>
         </ESO_Discord_RichPresence_Client.Properties.Settings>
     </userSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="KeraLua" publicKeyToken="6a194c04b9c89217" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.13.0" newVersion="1.2.13.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/ESO_Discord_RichPresence_Client/Classes/EsoCharacter.cs
+++ b/ESO_Discord_RichPresence_Client/Classes/EsoCharacter.cs
@@ -101,21 +101,21 @@ namespace ESO_Discord_RichPresence_Client
             this.Account = (string)character["account"];
             this.Race = (string)character["race"];
             this.Class = (string)character["class"];
-            this.genderInt = (int)(double)character["gender"];
-            this.allianceInt = (int)(double)character["alliance"];
+            this.genderInt = (int)(long)character["gender"];
+            this.allianceInt = (int)(long)character["alliance"];
             this.ParentZone = (string)character["parentZone"];
             this.Zone = (string)character["zone"];
             this.SubZone = (string)character["subZone"];
             this.IsChampion = (bool)character["isChampion"];
-            this.Level = (int)(double)character["level"];
+            this.Level = (int)(long)character["level"];
 
             this.IsGrouped = (bool)character["isGrouped"];
-            this.GroupSize = (int)(double)character["groupSize"];
-            this.groupRoleInt = (int)(double)character["groupRole"];
+            this.GroupSize = (int)(long)character["groupSize"];
+            this.groupRoleInt = (int)(long)character["groupRole"];
             this.InDungeon = (bool)character["inDungeon"];
-            this.dungeonDifficultyInt = (int)(double)character["isDungeonVeteran"];
+            this.dungeonDifficultyInt = (int)(long)character["isDungeonVeteran"];
 
-            this.Battlegrounds_GameType = (int)(double)character["bg_GameType"];
+            this.Battlegrounds_GameType = (int)(long)character["bg_GameType"];
             this.Battlegrounds_Name = (string)character["bg_Name"];
             this.Battlegrounds_Description = (string)character["bg_Description"];
 

--- a/ESO_Discord_RichPresence_Client/Discord/DiscordRpc.cs
+++ b/ESO_Discord_RichPresence_Client/Discord/DiscordRpc.cs
@@ -198,7 +198,7 @@ public class DiscordRpc
                 return str;
             }
 
-            var newstrbytes = new byte[] { };
+            var newstrbytes = new byte[maxbytes];
             Array.Copy(strbytes, 0, newstrbytes, 0, maxbytes - 1);
             newstrbytes[newstrbytes.Length - 1] = 0;
             newstrbytes[newstrbytes.Length - 2] = 0;

--- a/ESO_Discord_RichPresence_Client/ESO_Discord_RichPresence_Client.csproj
+++ b/ESO_Discord_RichPresence_Client/ESO_Discord_RichPresence_Client.csproj
@@ -114,6 +114,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
+      xcopy /s /y "..\..\..\packages\NLua.1.5.7\lib\net46\*.*" "$(TargetDir)"
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>

--- a/ESO_Discord_RichPresence_Client/ESO_Discord_RichPresence_Client.csproj
+++ b/ESO_Discord_RichPresence_Client/ESO_Discord_RichPresence_Client.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,11 +37,11 @@
     <ApplicationIcon>esodiscord.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="KeraLua, Version=1.3.2.0, Culture=neutral, PublicKeyToken=04d04586786c6f34, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLua.1.3.2.1\lib\net45\KeraLua.dll</HintPath>
+    <Reference Include="KeraLua, Version=1.2.13.0, Culture=neutral, PublicKeyToken=6a194c04b9c89217, processorArchitecture=MSIL">
+      <HintPath>..\packages\KeraLua.1.2.13\lib\net46\KeraLua.dll</HintPath>
     </Reference>
-    <Reference Include="NLua, Version=1.3.2.0, Culture=neutral, PublicKeyToken=8df2ab518030ea95, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLua.1.3.2.1\lib\net45\NLua.dll</HintPath>
+    <Reference Include="NLua, Version=1.5.7.0, Culture=neutral, PublicKeyToken=6a194c04b9c89217, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLua.1.5.7\lib\net46\NLua.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -112,11 +114,17 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
-      xcopy /s /y "..\..\..\packages\NLua.1.3.2.1\lib\native\*.*" "$(TargetDir)"
-</PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>echo "Packaging AddOn directory..."
 "$(SolutionDir)PackAddonFiles\$(OutDir)PackAddonFiles.exe" "$(SolutionDir)AddOn" "$(ProjectDir)ADDON.PAF"</PreBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\KeraLua.1.2.13\build\net46\KeraLua.targets" Condition="Exists('..\packages\KeraLua.1.2.13\build\net46\KeraLua.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\KeraLua.1.2.13\build\net46\KeraLua.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\KeraLua.1.2.13\build\net46\KeraLua.targets'))" />
+  </Target>
 </Project>

--- a/ESO_Discord_RichPresence_Client/packages.config
+++ b/ESO_Discord_RichPresence_Client/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLua" version="1.3.2.1" targetFramework="net461" />
+  <package id="KeraLua" version="1.2.13" targetFramework="net461" />
+  <package id="NLua" version="1.5.7" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Fixed #28 
Updated NLua to version 1.5.7 because 1.3.2.1 cannot read UTF8 files.
Works on Russian localization (and should work on other ones).
Attached my saved variables for testing purposes [DiscordRichPresence.txt](https://github.com/Medallyon/eso-discord-rich-presence-client/files/6367498/DiscordRichPresence.txt)

Have a small issue, that location image and class image are not displayed in Discord. I think, because of Russian localization of location and class name.
